### PR TITLE
Check body.authentication

### DIFF
--- a/lib/SchemaConnector.js
+++ b/lib/SchemaConnector.js
@@ -211,6 +211,12 @@ module.exports = class SchemaConnector {
         GlobalErrorTypes.BAD_REQUEST);
     }
 
+    if (!body.authentication) {
+      return new STBase('missingAuthentication', 'unavailable').setError(
+        `Invalid ST Schema request. No 'authentication' field present.`,
+        GlobalErrorTypes.BAD_REQUEST);
+    }
+
     let response;
     switch (body.headers.interactionType) {
       case "discoveryRequest":

--- a/test/lib/SchemaConnector-test.js
+++ b/test/lib/SchemaConnector-test.js
@@ -288,12 +288,32 @@ describe('SchemaConnector', function() {
     });
   });
 
-  describe('invalidRequest', function() {
+  describe('invalidRequest : missing headers', function() {
     it('Should return proper error response', async function() {
       const response = await schemaConnector.handleCallback({
         "item": {
           "tokenType": "Bearer",
           "token": "ACCT-HCtR4Q"
+        }
+      });
+
+      response.should.have.property('headers');
+      response.headers.schema.should.equal('st-schema');
+      response.headers.version.should.equal('1.0');
+      response.isError().should.equal(true);
+      response.should.have.property('globalError');
+      response.globalError.errorEnum.should.equal('BAD-REQUEST')
+    });
+  });
+
+  describe('invalidRequest : missing authentication', function() {
+    it('Should return proper error response', async function() {
+      const response = await schemaConnector.handleCallback({
+        "headers": {
+          "schema": "st-schema",
+          "version": "1.0",
+          "interactionType": "discoverRequest",
+          "requestId": "3d41b3d6-b328-68b8-351a-8c0c2303adb1"
         }
       });
 
@@ -314,6 +334,10 @@ describe('SchemaConnector', function() {
           "version": "1.0",
           "interactionType": "someOtherRequest",
           "requestId": "3d41b3d6-b328-68b8-351a-8c0c2303adb1"
+        },
+        "authentication": {
+          "tokenType": "Bearer",
+          "token": "ACCT-HCtR4Q"
         }
       });
 


### PR DESCRIPTION
Fixes #29 

Hi,
in the [SchemaConnector file](https://github.com/SmartThingsCommunity/st-schema-nodejs/blob/master/lib/SchemaConnector.js), for each interaction type, the `token` is directly taken from the `body.authentication`, but if it don't exist, the error `TypeError: Cannot read property 'token' of undefined` is thrown.

Accord to [SmartThings documentation](https://smartthings.developer.samsung.com/docs/devices/smartthings-schema/smartthings-schema-reference.html#Error-Responses), this case can throw a specific error : 
```
{
...
  "globalError": {
    "errorEnum": "BAD-REQUEST",
    "detail": "missing st-schema authentication"
  },
...
}
```

It will improve the schema compliance.