### PR TITLE
Use clientSecret option for client secret

### DIFF
--- a/lib/SchemaConnector.js
+++ b/lib/SchemaConnector.js
@@ -23,7 +23,7 @@ module.exports = class SchemaConnector {
 
   constructor(options = {}) {
     this[clientId] = options.clientId;
-    this[clientSecret] = options.clientId;
+    this[clientSecret] = options.clientSecret;
 
     this[discoveryHandler] = ((accessToken, response, data) => {
       console.log('discoverDevices not defined')


### PR DESCRIPTION
Update the `SchemaConnector` constructor to set the client secret using the `clientSecret` option rather than the `clientId`.