### PR TITLE
Fixed Device.setError to correctly create an array property

### DIFF
--- a/lib/state/StateDevice.js
+++ b/lib/state/StateDevice.js
@@ -88,7 +88,10 @@ class Device {
   }
 
   setError(detail, errorEnum = "UNKNOWN-ERROR") {
-    this.deviceError = {errorEnum, detail};
+    if (!this.deviceError) {
+      this.deviceError = [];
+    }
+    this.deviceError.push({errorEnum, detail});
     return this;
   }
 }


### PR DESCRIPTION
Previously `Device.setError` was creating the `deviceError` property as an object instead of the correct definition as an array of error objects.