### PR TITLE
fix: Send global errors when set in callbacks

### DIFF
--- a/lib/callbacks/AccessTokenRequest.js
+++ b/lib/callbacks/AccessTokenRequest.js
@@ -24,6 +24,10 @@ module.exports = class AccessTokenRequest extends STBase {
       }
     };
 
+    if (this.globalError) {
+      body.globalError = this.globalError
+    }
+
     const options = {
       method: 'POST',
       headers: {

--- a/lib/callbacks/DiscoveryRequest.js
+++ b/lib/callbacks/DiscoveryRequest.js
@@ -64,6 +64,10 @@ module.exports = class DiscoveryRequest extends STBase {
       devices: this.devices
     };
 
+    if (this.globalError) {
+      body.globalError = this.globalError
+    }
+
     const options = {
       method: 'POST',
       headers: {

--- a/lib/callbacks/RefreshTokenRequest.js
+++ b/lib/callbacks/RefreshTokenRequest.js
@@ -24,6 +24,10 @@ module.exports = class RefreshTokenRequest extends STBase {
       }
     };
 
+    if (this.globalError) {
+      body.globalError = this.globalError
+    }
+
     const options = {
       method: 'POST',
       headers: {

--- a/lib/callbacks/StateUpdateRequest.js
+++ b/lib/callbacks/StateUpdateRequest.js
@@ -45,6 +45,10 @@ module.exports = class StateUpdateRequest extends STBase {
       deviceState: deviceState
     };
 
+    if (this.globalError) {
+      body.globalError = this.globalError
+    }
+
     const options = {
       method: 'POST',
       headers: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "st-schema",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SmartThings Schema for C2C integration",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Removing a connection from the partner cloud requires a global integration deleted errors to be sent as a callback, but none of the callback classes were including the error in the request. This particular scenario only requires that DiscoveryRequest include the error but I updated all of the callback classes to do so for consistency, and in case other scenarios come up later.