### PR TITLE
Readme and Error report option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ const connector = new SchemaConnector()
      * @response {DiscoveryResponse} Discovery response object
      */
   })
-  .stateRefreshHandler((accessToken, response) => {
+  .stateRefreshHandler((accessToken, response, data) => {
     /**
-     * State refresh request. Respond with the current states of all devices. Called after
-     * device discovery runs.
+     * State refresh request. Respond with the current states of the requested devices. Called after
+     * device discovery runs and every time the information is refreshed, the list of required devices is in data.devices
      * @accessToken External cloud access token
      * @response {StateRefreshResponse} StateRefresh response object
      */

--- a/lib/state/StateResponse.js
+++ b/lib/state/StateResponse.js
@@ -47,7 +47,7 @@ class StateResponse extends STBase {
    * @param {string} externalDeviceId
    * @returns {StateDevice}
    */
-  addDevice(externalDeviceId, states) {
+  addDevice(externalDeviceId, states, error) {
     if (! this.deviceState) {
       this.deviceState = [];
     }
@@ -58,6 +58,9 @@ class StateResponse extends STBase {
       for (const state of states) {
         device.addState(state)
       }
+    }
+    if (error) { 
+        device.setError(error.detail, error.errorEnum)
     }
     return device;
   }


### PR DESCRIPTION
The current documentation says that stateRefreshHandler responds with the state of all devices, but it is necessary to respond with the state of the requested devices, otherwise, there is an error callback.

There is a function for adding device errors to the response but there is no way to use it from the StateResponse class.
I just added it