### PR TITLE
C2C-1697 Removed undefined interaction types

### DIFF
--- a/lib/SchemaConnector.js
+++ b/lib/SchemaConnector.js
@@ -229,13 +229,13 @@ module.exports = class SchemaConnector {
     }
 
     if (!body.headers) {
-      return new STBase('missingHeader', 'unavailable').setError(
+      return new STBase().setError(
         `Invalid ST Schema request. No 'headers' field present.`,
         GlobalErrorTypes.BAD_REQUEST);
     }
 
     if (!body.authentication) {
-      return new STBase('missingAuthentication', 'unavailable').setError(
+      return new STBase().setError(
         `Invalid ST Schema request. No 'authentication' field present.`,
         GlobalErrorTypes.BAD_REQUEST);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "st-schema",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "SmartThings Schema for C2C integration",
   "main": "index.js",
   "directories": {

--- a/test/lib/SchemaConnector-test.js
+++ b/test/lib/SchemaConnector-test.js
@@ -8,10 +8,7 @@ const sinon = require('sinon');
 let interactionResultCount = 0;
 const testClientId = 'xxxx';
 const testClientSecret = 'yyyy';
-const testCallbackUrls = {
-  oauthToken: 'https://smartthings/token',
-  stateCallback: 'https://smartthings/callback'
-};
+
 const textCallbackAuth = {
   accessToken: 'aaaa-zzzz',
   refreshToken: 'yyyy-bbbb'
@@ -169,7 +166,7 @@ describe('SchemaConnector', function() {
         }
       });
 
-      const response = await schemaConnector.handleCallback({
+      await schemaConnector.handleCallback({
         "headers": {
           "schema": "st-schema",
           "version": "1.0",
@@ -608,6 +605,7 @@ describe('SchemaConnector', function() {
         }, res);
 
       res.statusCode.should.equal(200)
+      res.data.globalError.errorEnum.should.equal('BAD-REQUEST')
     });
 
     it('Should handle thrown error', async function() {
@@ -627,6 +625,32 @@ describe('SchemaConnector', function() {
           }}, res);
 
       res.statusCode.should.equal(500)
+    });
+
+    it('Should handle empty request', async function() {
+      const res = new HttpResponse()
+      await schemaConnector.handleHttpCallback(
+          {body: {}
+          }, res);
+
+      res.statusCode.should.equal(200)
+      res.data.globalError.errorEnum.should.equal('BAD-REQUEST')
+    });
+
+    it('Should handle missing auth', async function() {
+      const res = new HttpResponse()
+      await schemaConnector.handleHttpCallback(
+          {body: {
+              "headers": {
+                "schema": "st-schema",
+                "version": "1.0",
+                "interactionType": "discoveryRequest",
+                "requestId": "0edb967a-380e-4699-968e-64ea31cef618"
+              }}
+          }, res);
+
+      res.statusCode.should.equal(200)
+      res.data.globalError.errorEnum.should.equal('BAD-REQUEST')
     });
   });
 


### PR DESCRIPTION
Removed undocumented interaction types and (missing) request IDs from responses to invalid requests. Some developers were expecting to find these interaction types in the documentation and they are not there. That's because the purpose or returning interaction type and request ID in error responses is to correlate them with requests, but in these cases that information is not available.